### PR TITLE
feat: set target and libs to ESNext rather than ES2018

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,29 @@
+node-cache: &node-cache
+  id: node
+  key: "v1-cache-{{ id }}-{{ runner.os }}-{{ checksum 'yarn.lock' }}"
+  restore-keys:
+    - 'v1-cache-{{ id }}-{{ runner.os }}-'
+    - 'v1-cache-{{ id }}-'
+  paths:
+    - node_modules
+
+all-plugins: &all-plugins
+  - gencer/cache#v2.4.8: *node-cache
+
+steps:
+  - label: 'Install'
+    command: NODE_ENV=development yarn install --frozen-lockfile
+    plugins: *all-plugins
+  - wait
+  - label: 'Test'
+    command: yarn test
+    plugins: *all-plugins
+  - wait
+  - label: 'Publish to registry'
+    if: build.tag != null
+    command:
+      - export PATH="./node_modules/.bin:$PATH"
+      - yarn publish
+    concurrency: 1
+    concurrency_group: 'goodeggs-tsconfig/publish'
+    plugins: *all-plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,23 +1,20 @@
-node-cache: &node-cache
-  id: node
-  key: "v1-cache-{{ id }}-{{ runner.os }}-{{ checksum 'yarn.lock' }}"
-  restore-keys:
-    - 'v1-cache-{{ id }}-{{ runner.os }}-'
-    - 'v1-cache-{{ id }}-'
-  paths:
-    - node_modules
+plugin-node-cache: &plugin-node-cache
+  cache_node: true
 
-all-plugins: &all-plugins
-  - gencer/cache#v2.4.8: *node-cache
+plugin-secrets: &plugin-secrets
+  secrets:
+    NPM_TOKEN: 'y5kWMs9vm9c/P3-Z-IAtiaB-0syFrd4wCQ/bmaYVrKaUgpIqtXs4g2suPEN-mosoBmM8LLR1w5SVEMU2_s4'
 
 steps:
   - label: 'Install'
     command: NODE_ENV=development yarn install --frozen-lockfile
-    plugins: *all-plugins
+    plugins:
+      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
   - wait
   - label: 'Test'
     command: yarn test
-    plugins: *all-plugins
+    plugins:
+      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
   - wait
   - label: 'Publish to registry'
     if: build.tag != null
@@ -26,4 +23,6 @@ steps:
       - yarn publish
     concurrency: 1
     concurrency_group: 'goodeggs-tsconfig/publish'
-    plugins: *all-plugins
+    plugins:
+      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
+      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-secrets

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,16 +5,18 @@ plugin-secrets: &plugin-secrets
   secrets:
     NPM_TOKEN: 'y5kWMs9vm9c/P3-Z-IAtiaB-0syFrd4wCQ/bmaYVrKaUgpIqtXs4g2suPEN-mosoBmM8LLR1w5SVEMU2_s4'
 
+plugins: &plugins
+  - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
+  - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-secrets
+
 steps:
   - label: 'Install'
     command: NODE_ENV=development yarn install --frozen-lockfile
-    plugins:
-      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
+    plugins: *plugins
   - wait
   - label: 'Test'
     command: yarn test
-    plugins:
-      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
+    plugins: *plugins
   - wait
   - label: 'Publish to registry'
     if: build.tag != null
@@ -23,6 +25,4 @@ steps:
       - yarn publish
     concurrency: 1
     concurrency_group: 'goodeggs-tsconfig/publish'
-    plugins:
-      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-node-cache
-      - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.0.18: *plugin-secrets
+    plugins: *plugins

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 2.0.0
+
+- fix(base): Fix `lib` option to _not_ include browser-specific libs (e.g. DOM)
+- feat: bump from hardcoded ES2018 target to ESNext

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Use the [`extends` property](https://www.typescriptlang.org/docs/handbook/tsconf
 ### Listing of Configurations
 
 - `@goodeggs/tsconfig/base`: A base configuration. Makes no assumptions about the environment you're targeting.
-- `@goodeggs/tsconfig/browser`: A base browser configuration. Assumes you are targeting a ES2018 feature set (and using Babel to achieve compatibility with older browsers if desired).
-- `@goodeggs/tsconfig/react`: A React/JSX configuration. Assumes you are targeting a ES2018 feature set (and using Babel to achieve compatibility with older browsers if desired).
+- `@goodeggs/tsconfig/browser`: A base browser configuration. Assumes you are targeting an ESNext feature set (and using Babel to achieve compatibility with older browsers if desired).
+- `@goodeggs/tsconfig/react`: A React/JSX configuration. Assumes you are targeting an ESNext feature set (and using Babel to achieve compatibility with older browsers if desired).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Use the [`extends` property](https://www.typescriptlang.org/docs/handbook/tsconf
 }
 ```
 
+## Releasing
+
+This repo is **not** currently configured to publish automatically from CI.
+
+To release a new version of this module, use yarn locally to publish the version and create the git tag, then push:
+```sh
+yarn publish --new-version=<major|minor|patch>
+git push --follow-tags
+```
+
 ### Listing of Configurations
 
 - `@goodeggs/tsconfig/base`: A base configuration. Makes no assumptions about the environment you're targeting.

--- a/base.json
+++ b/base.json
@@ -11,6 +11,7 @@
     // This prevents stripping comments from typedef files
     "removeComments": false,
     "strict": true,
-    "target": "es2018"
+    // This configuration is designed to be used with Babel and @babel/preset-env
+    "target": "ESNext"
   }
 }

--- a/base.json
+++ b/base.json
@@ -2,6 +2,11 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    // Explicitly only include ESNext libs, since TS for some reason includes browser-specific
+    // libs (DOM) by default, which can be confusing and error-prone.
+    "lib": [
+      "ESNext"
+    ],
     "module": "commonjs",
     // This configuration is designed to be used with Babel, so turn asset output off
     "noEmit": true,

--- a/browser.json
+++ b/browser.json
@@ -2,9 +2,9 @@
   "extends": "./base",
   "compilerOptions": {
     "lib": [
-      "dom",
-      "dom.iterable",
-      "es2018"
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bugs": {
     "url": "https://github.com/goodeggs/goodeggs-tsconfig/issues"
   },
+  "scripts": {
+    "test": "echo 'No tests yet'"
+  },
   "homepage": "https://github.com/goodeggs/goodeggs-tsconfig#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
   "bugs": {
     "url": "https://github.com/goodeggs/goodeggs-tsconfig/issues"
   },
-  "homepage": "https://github.com/goodeggs/goodeggs-tsconfig#readme"
+  "homepage": "https://github.com/goodeggs/goodeggs-tsconfig#readme",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodeggs/tsconfig",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared Good Eggs TypeScript configurations.",
   "repository": "git@github.com:goodeggs/goodeggs-tsconfig.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodeggs/tsconfig",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared Good Eggs TypeScript configurations.",
   "repository": "git@github.com:goodeggs/goodeggs-tsconfig.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodeggs/tsconfig",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Shared Good Eggs TypeScript configurations.",
   "repository": "git@github.com:goodeggs/goodeggs-tsconfig.git",
   "license": "MIT",


### PR DESCRIPTION
### 959a946 feat: set target and libs to ESNext rather than ES2018

And use the canonical casing at the same time.

See https://www.typescriptlang.org/tsconfig.

 ### 01e5590 fix: explicitly configure libs to avoid leaking browser libs to node

For some reason the default is to include the DOM lib! This makes no sense in a node project. See https://www.typescriptlang.org/tsconfig.

This could end up being a 'breaking' change for some consumers. It will fail CI in those repos, so quite easy to catch.

 ### adfe3f2 chore: add missing NPM registry config